### PR TITLE
Fix installation command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Service Name | Import Path
 ## Installation
 
 ```sh
-npm install eventstreams-sdk
+npm install eventstreams_sdk
 ```
 
 ## Using the SDK


### PR DESCRIPTION
With a dash, I got:

```
npm ERR! code E404
npm ERR! 404 Not Found - GET https://registry.npmjs.org/eventstreams-sdk - Not found
npm ERR! 404
npm ERR! 404  'eventstreams-sdk@*' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
```

Found the package name with an underscore on npmjs.com [here](https://www.npmjs.com/package/eventstreams_sdk). Installing with the underscore instead of a dash worked. This PR updates the installation command.