### PR TITLE
chore(build): bump travis to supported node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 sudo: false
 
 node_js:
-- 10
-- 12
+- 14
+- 16
 
 before_install:
 - echo -e "machine github.ibm.com\n  login $GITHUB_OAUTH_TOKEN" > ~/.netrc


### PR DESCRIPTION
v10 is long out of support and v12 is due to go EOL in a couple of
months so move testing to v14 and v16

https://nodejs.org/en/about/releases/
