### PR TITLE
fix(ci): use PAT token for alert-lookup

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -20,10 +20,14 @@ jobs:
       uses: dependabot/fetch-metadata@v1.3.5
       with:
         alert-lookup: true
-        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        github-token: "${{ secrets.PAT_GITHUB_TOKEN_ALERT_LOOKUP }}" # PAT token with only security_events scope
     - name: Approve and enable auto-merge for Dependabot alert PRs
       if: ${{contains(steps.metadata.outputs.alert-state, 'OPEN') && steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
-      run: gh pr review --approve "$PR_URL" && gh pr merge --auto --merge --squash "$PR_URL"
+      run: >-
+        set -eu
+        gh pr edit --add-label "security" "$PR_URL"
+        gh pr review --approve "$PR_URL"
+        gh pr merge --auto --merge --squash "$PR_URL"
       env:
         PR_URL: ${{github.event.pull_request.html_url}}
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Unfortunately this can't just be done using the `permissions:` directive