### PR TITLE
chore(ci): fix `gh pr merge` syntax

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -27,7 +27,7 @@ jobs:
         set -eu
         gh pr edit --add-label "security" "$PR_URL"
         gh pr review --approve "$PR_URL"
-        gh pr merge --auto --merge --squash "$PR_URL"
+        gh pr merge --auto --squash "$PR_URL"
       env:
         PR_URL: ${{github.event.pull_request.html_url}}
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Accidentally included both `--merge` and `--squash` when only the latter is needed.
